### PR TITLE
Feature/#67 proposal for integration testing webenvironment

### DIFF
--- a/simulator-samples/pom.xml
+++ b/simulator-samples/pom.xml
@@ -3,6 +3,9 @@
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
   <modelVersion>4.0.0</modelVersion>
+  <artifactId>citrus-simulator-samples</artifactId>
+  <name>${project.artifactId}</name>
+  <packaging>pom</packaging>
 
   <parent>
     <groupId>com.consol.citrus</groupId>
@@ -11,21 +14,14 @@
     <relativePath>../pom.xml</relativePath>
   </parent>
 
-  <artifactId>citrus-simulator-samples</artifactId>
-  <name>${project.artifactId}</name>
-
-  <packaging>pom</packaging>
-
   <properties>
-    <spring.boot.start.wait>1000</spring.boot.start.wait>
-    <spring.boot.start.maxAttempts>60</spring.boot.start.maxAttempts>
     <skip.it>false</skip.it>
   </properties>
 
   <modules>
     <module>sample-bank-service</module>
     <module>sample-rest</module>
-    <!--module>sample-swagger</module-->
+	<!-- <module>sample-swagger</module> -->
     <module>sample-ws</module>
     <module>sample-ws-client</module>
     <module>sample-wsdl</module>

--- a/simulator-samples/sample-bank-service/pom.xml
+++ b/simulator-samples/sample-bank-service/pom.xml
@@ -58,6 +58,19 @@
       <artifactId>testng</artifactId>
       <scope>test</scope>
     </dependency>
+
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-test</artifactId>
+      <scope>test</scope>
+
+      <exclusions>
+        <exclusion>
+          <groupId>junit</groupId>
+          <artifactId>junit</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
   </dependencies>
 
   <build>
@@ -96,31 +109,8 @@
               <classifier>executable</classifier>
             </configuration>
           </execution>
-          <execution>
-            <id>pre-integration-test</id>
-            <goals>
-              <goal>start</goal>
-            </goals>
-            <configuration>
-              <skip>${skip.it}</skip>
-              <fork>true</fork>
-              <wait>${spring.boot.start.wait}</wait>
-              <maxAttempts>${spring.boot.start.maxAttempts}</maxAttempts>
-            </configuration>
-          </execution>
-          <execution>
-            <id>post-integration-test</id>
-            <goals>
-              <goal>stop</goal>
-            </goals>
-            <configuration>
-              <skip>${skip.it}</skip>
-              <fork>true</fork>
-            </configuration>
-          </execution>
         </executions>
       </plugin>
     </plugins>
   </build>
-
 </project>

--- a/simulator-samples/sample-bank-service/src/main/resources/META-INF/citrus-simulator-context.xml
+++ b/simulator-samples/sample-bank-service/src/main/resources/META-INF/citrus-simulator-context.xml
@@ -8,5 +8,4 @@
     <citrus:global-variables>
         <citrus:variable name="simulator.name" value="${info.simulator.name}"/>
     </citrus:global-variables>
-
 </beans>

--- a/simulator-samples/sample-bank-service/src/main/resources/application.properties
+++ b/simulator-samples/sample-bank-service/src/main/resources/application.properties
@@ -1,10 +1,10 @@
 info.simulator.name=Citrus Bank Simulator
-logging.level.com.consol.citrus=DEBUG
 
 logging.level.com.consol.citrus=DEBUG
+
+server.port=8443
 
 # SSL Configuration for HTTPS endpoint
-server.port=8443
 server.ssl.key-alias=selfsigned_localhost_sslserver
 server.ssl.key-password=simulator
 server.ssl.key-store=classpath:Keystore/ssl-server.jks
@@ -13,7 +13,6 @@ server.ssl.key-store-type=JKS
 
 # Enable Http REST support
 citrus.simulator.rest.enabled=true
-
 # Default timeout setting for HTTP requests and responses
 citrus.simulator.defaultTimeout=5000
 # Default message template path

--- a/simulator-samples/sample-bank-service/src/test/java/com/consol/citrus/simulator/config/SSLRestTemplateConfiguration.java
+++ b/simulator-samples/sample-bank-service/src/test/java/com/consol/citrus/simulator/config/SSLRestTemplateConfiguration.java
@@ -1,0 +1,29 @@
+package com.consol.citrus.simulator.config;
+
+import java.security.KeyManagementException;
+import java.security.KeyStoreException;
+import java.security.NoSuchAlgorithmException;
+
+import org.apache.http.client.HttpClient;
+import org.apache.http.conn.ssl.NoopHostnameVerifier;
+import org.apache.http.conn.ssl.TrustSelfSignedStrategy;
+import org.apache.http.impl.client.HttpClients;
+import org.apache.http.ssl.SSLContextBuilder;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.client.HttpComponentsClientHttpRequestFactory;
+import org.springframework.web.client.RestTemplate;
+
+@Configuration
+public class SSLRestTemplateConfiguration {
+
+    @Bean
+    public RestTemplate sslRestTemplate() throws NoSuchAlgorithmException, KeyStoreException, KeyManagementException {
+        SSLContextBuilder sslcontext = new SSLContextBuilder().loadTrustMaterial(null, new TrustSelfSignedStrategy());
+
+        HttpClient client = HttpClients.custom().setSSLContext(sslcontext.build())
+                .setSSLHostnameVerifier(NoopHostnameVerifier.INSTANCE).build();
+
+        return new RestTemplate(new HttpComponentsClientHttpRequestFactory(client));
+    }
+}


### PR DESCRIPTION
The way the integration tests are set up isn't quit satisfying. It is a complex process via citrus handlers and reflection invocking the starters which execute server requests. But, those just in a mocked environment.
It is a far better approach to use the tools delivered by Spring and realistically call the server via `RestClient`.
I chose the `sample-bank-service` for this proposal because it includes a SSL-secured API. Therefore, I had to modify the `RestTemplate` in order to accept the self signed certificate.

@svettwer @boskoop 